### PR TITLE
fix: Windows home dir path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ func InitConfig() {
 		viper.SetConfigName(".qbt")
 		viper.AddConfigPath(".") // optionally look for config in the working directory
 		viper.AddConfigPath(home)
-		viper.AddConfigPath("$HOME/.config/qbt") // call multiple times to add many search paths
+		viper.AddConfigPath(home + "/.config/qbt") // call multiple times to add many search paths
 	}
 
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
On PowerShell / CMD the HOME environment variable is often not defined, so $HOME/.config/qbt will evaluate to C:/.config/qbt instead of C:/<username>/.config/qbt as one would expect.